### PR TITLE
E-2467: GraphQL calls use API Key in Authorization Header

### DIFF
--- a/src/bot/applicationCommands/events/redeemCode.ts
+++ b/src/bot/applicationCommands/events/redeemCode.ts
@@ -150,7 +150,7 @@ export default class RedeemCode extends ApplicationCommand {
 				flags: MessageFlags.Ephemeral,
 			});
 
-		const userExistsResponse = await fetch(`https://api.runpod.io/graphql?api_key=${env.RUNPOD_API_KEY}`, {
+		const userExistsResponse = await fetch(`https://api.runpod.io/graphql`, {
 			method: "POST",
 			body: JSON.stringify({
 				operationName: "getUserByEmail",
@@ -166,6 +166,7 @@ export default class RedeemCode extends ApplicationCommand {
 				"User-Agent":
 					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
 				"Content-Type": "application/json",
+				"Authorization": `Bearer ${env.RUNPOD_API_KEY}`,
 			},
 		});
 
@@ -193,7 +194,7 @@ export default class RedeemCode extends ApplicationCommand {
 				allowed_mentions: { parse: [], replied_user: true },
 			});
 
-		const generatedCodeResponse = await fetch(`https://api.runpod.io/graphql?api_key=${env.RUNPOD_API_KEY}`, {
+		const generatedCodeResponse = await fetch(`https://api.runpod.io/graphql`, {
 			method: "POST",
 			body: JSON.stringify({
 				operationName: "generateCode",
@@ -208,6 +209,7 @@ export default class RedeemCode extends ApplicationCommand {
 				"User-Agent":
 					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
 				"Content-Type": "application/json",
+				"Authorization": `Bearer ${env.RUNPOD_API_KEY}`,
 			},
 		});
 


### PR DESCRIPTION
Follow-up to https://github.com/runpod/RunPod/pull/2436