### PR TITLE
tag command

### DIFF
--- a/lib/classes/ApplicationCommand.ts
+++ b/lib/classes/ApplicationCommand.ts
@@ -186,17 +186,14 @@ export default class ApplicationCommand {
 
 			const guildOwnerId = this.client.guildOwnersCache.get(interaction.guild_id);
 
-			if (guildOwnerId !== (interaction.member?.user ?? interaction.user!).id)
+			if (guildOwnerId !== (interaction.member ?? interaction).user!.id)
 				return {
 					title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 					description: language.get("MISSING_PERMISSIONS_OWNER_ONLY_DESCRIPTION", {
 						type,
 					}),
 				};
-		} else if (
-			this.devOnly &&
-			!this.client.config.admins.includes((interaction.member?.user ?? interaction.user!).id || "")
-		)
+		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member ?? interaction).user!.id || ""))
 			return {
 				title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 				description: language.get("MISSING_PERMISSIONS_DEVELOPER_ONLY_DESCRIPTION", {
@@ -237,9 +234,7 @@ export default class ApplicationCommand {
 						throw error;
 					}
 
-				if (
-					(interaction.member?.user ?? interaction.user!).id !== this.client.guildOwnersCache.get(interaction.guild_id)
-				)
+				if ((interaction.member ?? interaction).user!.id !== this.client.guildOwnersCache.get(interaction.guild_id))
 					return {
 						title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 						description: language.get(
@@ -320,7 +315,7 @@ export default class ApplicationCommand {
 					commandName_commandType_userId: {
 						commandName: this.name,
 						commandType: "APPLICATION_COMMAND",
-						userId: (interaction.member?.user ?? interaction.user!).id,
+						userId: (interaction.member ?? interaction).user!.id,
 					},
 				},
 			});

--- a/lib/classes/AutoCompleteHandler.ts
+++ b/lib/classes/AutoCompleteHandler.ts
@@ -140,12 +140,12 @@ export default class AutoCompleteHandler<C extends ExtendedClient = ExtendedClie
 
 		const userLanguage = await this.client.prisma.userLanguage.findUnique({
 			where: {
-				userId: (interaction.member?.user ?? interaction.user!).id,
+				userId: (interaction.member ?? interaction).user!.id,
 			},
 		});
 		const language = this.client.languageHandler.getLanguage(userLanguage?.languageId ?? interaction.locale);
 
-		this.client.dataDog.increment("autocomplete_responses", 1, [`name:${name.join("-")}`, `shard:${shardId}`]);
+		this.client.dataDog?.increment("autocomplete_responses", 1, [`name:${name.join("-")}`, `shard:${shardId}`]);
 
 		return this.runAutoComplete(autoComplete, interactionWithArguments, language, shardId);
 	}

--- a/lib/classes/Button.ts
+++ b/lib/classes/Button.ts
@@ -122,7 +122,7 @@ export default class Button {
 						type: "button",
 					}),
 				};
-		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member?.user ?? interaction.user!).id))
+		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member ?? interaction).user!.id))
 			return {
 				title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 				description: language.get("MISSING_PERMISSIONS_DEVELOPER_ONLY_DESCRIPTION", {

--- a/lib/classes/ButtonHandler.ts
+++ b/lib/classes/ButtonHandler.ts
@@ -91,7 +91,7 @@ export default class ButtonHandler<C extends ExtendedClient = ExtendedClient> {
 	}: Omit<ToEventProps<APIMessageComponentButtonInteraction>, "api">) {
 		const userLanguage = await this.client.prisma.userLanguage.findUnique({
 			where: {
-				userId: (interaction.member?.user ?? interaction.user!).id,
+				userId: (interaction.member ?? interaction).user!.id,
 			},
 		});
 		const language = this.client.languageHandler.getLanguage(userLanguage?.languageId ?? interaction.locale);
@@ -155,7 +155,7 @@ export default class ButtonHandler<C extends ExtendedClient = ExtendedClient> {
 		shardId: number,
 		language: Language,
 	) {
-		if (this.cooldowns.has((interaction.member?.user ?? interaction.user!).id))
+		if (this.cooldowns.has((interaction.member ?? interaction).user!.id))
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {
 				embeds: [
 					{
@@ -211,7 +211,7 @@ export default class ButtonHandler<C extends ExtendedClient = ExtendedClient> {
 			}
 		}
 
-		this.cooldowns.add((interaction.member?.user ?? interaction.user!).id);
-		setTimeout(() => this.cooldowns.delete((interaction.member?.user ?? interaction.user!).id), this.coolDownTime);
+		this.cooldowns.add((interaction.member ?? interaction).user!.id);
+		setTimeout(() => this.cooldowns.delete((interaction.member ?? interaction).user!.id), this.coolDownTime);
 	}
 }

--- a/lib/classes/EventHandler.ts
+++ b/lib/classes/EventHandler.ts
@@ -43,7 +43,7 @@ export default class EventHandler<C extends ExtendedClient = ExtendedClient> {
 	 * @returns The result of our event.
 	 */
 	private async _run(...args: any[]) {
-		this.client.dataDog.increment("websocket_events", 1, [`type:${this.name}`]);
+		this.client.dataDog?.increment("websocket_events", 1, [`type:${this.name}`]);
 
 		try {
 			return await this.run(...args);

--- a/lib/classes/Modal.ts
+++ b/lib/classes/Modal.ts
@@ -120,7 +120,7 @@ export default class Modal<C extends ExtendedClient = ExtendedClient> {
 					title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 					description: language.get("MISSING_PERMISSIONS_OWNER_ONLY_DESCRIPTION", { type: "modal" }),
 				};
-		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member?.user ?? interaction.user!).id))
+		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member ?? interaction).user!.id))
 			return {
 				title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 				description: language.get("MISSING_PERMISSIONS_DEVELOPER_ONLY_DESCRIPTION", { type: "modal" }),

--- a/lib/classes/ModalHandler.ts
+++ b/lib/classes/ModalHandler.ts
@@ -84,7 +84,7 @@ export default class ModalHandler<C extends ExtendedClient = ExtendedClient> {
 	public async handleModal({ data: interaction, shardId }: Omit<ToEventProps<APIModalSubmitInteraction>, "api">) {
 		const userLanguage = await this.client.prisma.userLanguage.findUnique({
 			where: {
-				userId: (interaction.member?.user ?? interaction.user!).id,
+				userId: (interaction.member ?? interaction).user!.id,
 			},
 		});
 		const language = this.client.languageHandler.getLanguage(userLanguage?.languageId ?? interaction.locale);
@@ -143,7 +143,7 @@ export default class ModalHandler<C extends ExtendedClient = ExtendedClient> {
 	 * @param language The language to use when replying to the interaction.
 	 */
 	private async runModal(modal: Modal, interaction: APIModalSubmitInteraction, shardId: number, language: Language) {
-		if (this.cooldowns.has((interaction.member?.user ?? interaction.user!).id))
+		if (this.cooldowns.has((interaction.member ?? interaction).user!.id))
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {
 				embeds: [
 					{
@@ -199,7 +199,7 @@ export default class ModalHandler<C extends ExtendedClient = ExtendedClient> {
 			}
 		}
 
-		this.cooldowns.add((interaction.member?.user ?? interaction.user!).id);
-		setTimeout(() => this.cooldowns.delete((interaction.member?.user ?? interaction.user!).id), this.coolDownTime);
+		this.cooldowns.add((interaction.member ?? interaction).user!.id);
+		setTimeout(() => this.cooldowns.delete((interaction.member ?? interaction).user!.id), this.coolDownTime);
 	}
 }

--- a/lib/classes/SelectMenu.ts
+++ b/lib/classes/SelectMenu.ts
@@ -120,7 +120,7 @@ export default class SelectMenu {
 					title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 					description: language.get("MISSING_PERMISSIONS_OWNER_ONLY_DESCRIPTION", { type: "select menu" }),
 				};
-		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member?.user ?? interaction.user!).id))
+		} else if (this.devOnly && !this.client.config.admins.includes((interaction.member ?? interaction).user!.id))
 			return {
 				title: language.get("MISSING_PERMISSIONS_BASE_TITLE"),
 				description: language.get("MISSING_PERMISSIONS_DEVELOPER_ONLY_DESCRIPTION", { type: "select menu" }),

--- a/lib/classes/SelectMenuHandler.ts
+++ b/lib/classes/SelectMenuHandler.ts
@@ -91,7 +91,7 @@ export default class SelectMenuHandler<C extends ExtendedClient = ExtendedClient
 	}: Omit<ToEventProps<APIMessageComponentSelectMenuInteraction>, "api">) {
 		const userLanguage = await this.client.prisma.userLanguage.findUnique({
 			where: {
-				userId: (interaction.member?.user ?? interaction.user!).id,
+				userId: (interaction.member ?? interaction).user!.id,
 			},
 		});
 		const language = this.client.languageHandler.getLanguage(userLanguage?.languageId ?? interaction.locale);
@@ -155,7 +155,7 @@ export default class SelectMenuHandler<C extends ExtendedClient = ExtendedClient
 		shardId: number,
 		language: Language,
 	) {
-		if (this.cooldowns.has((interaction.member?.user ?? interaction.user!).id))
+		if (this.cooldowns.has((interaction.member ?? interaction).user!.id))
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {
 				embeds: [
 					{
@@ -211,7 +211,7 @@ export default class SelectMenuHandler<C extends ExtendedClient = ExtendedClient
 			}
 		}
 
-		this.cooldowns.add((interaction.member?.user ?? interaction.user!).id);
-		setTimeout(() => this.cooldowns.delete((interaction.member?.user ?? interaction.user!).id), this.coolDownTime);
+		this.cooldowns.add((interaction.member ?? interaction).user!.id);
+		setTimeout(() => this.cooldowns.delete((interaction.member ?? interaction).user!.id), this.coolDownTime);
 	}
 }

--- a/lib/classes/TextCommandHandler.ts
+++ b/lib/classes/TextCommandHandler.ts
@@ -195,14 +195,14 @@ export default class TextCommandHandler<C extends ExtendedClient = ExtendedClien
 
 			if (textCommand.cooldown) await textCommand.applyCooldown(message.author.id);
 
-			this.client.dataDog.increment("command_used", 1, [
+			this.client.dataDog?.increment("command_used", 1, [
 				`command:${textCommand.name}`,
 				"type:text",
 				"success:true",
 				`shard:${shardId}`,
 			]);
 		} catch (error) {
-			this.client.dataDog.increment("command_used", 1, [
+			this.client.dataDog?.increment("command_used", 1, [
 				`command:${textCommand.name}`,
 				"type:text",
 				"success:false",

--- a/lib/extensions/ExtendedClient.ts
+++ b/lib/extensions/ExtendedClient.ts
@@ -165,9 +165,9 @@ export default class ExtendedClient extends Client {
 	public readonly modalHandler: ModalHandler<this>;
 
 	/**
-	 * Our data dog client.
+	 * Our DataDog client.
 	 */
-	public readonly dataDog: typeof metrics;
+	public readonly dataDog?: typeof metrics;
 
 	/**
 	 * A map of guild IDs to a set of user IDs, representing a guild and who is in a voice channel.
@@ -196,7 +196,7 @@ export default class ExtendedClient extends Client {
 
 		this.config = Config;
 		this.config.version =
-			execSync("git rev-parse HEAD").toString().trim().slice(0, 7) + env.NODE_ENV === "development" ? "dev" : "";
+			env.NODE_ENV === "production" ? execSync("git rev-parse --short HEAD").toString().trim() : "dev";
 
 		this.logger = Logger;
 		this.options = options;
@@ -254,15 +254,17 @@ export default class ExtendedClient extends Client {
 			});
 		}
 
-		// @ts-expect-error
-		this.dataDog = metrics.default;
+		if (env.DATADOG_API_KEY) {
+			// @ts-expect-error
+			this.dataDog = metrics.default;
 
-		this.dataDog.init({
-			flushIntervalSeconds: 0,
-			apiKey: env.DATADOG_API_KEY,
-			prefix: `${this.config.botName.toLowerCase().split(" ").join("_")}.`,
-			defaultTags: [`env:${env.NODE_ENV}`],
-		});
+			this.dataDog?.init({
+				flushIntervalSeconds: 0,
+				apiKey: env.DATADOG_API_KEY,
+				prefix: `${this.config.botName.toLowerCase().split(" ").join("_")}.`,
+				defaultTags: [`env:${env.NODE_ENV}`],
+			});
+		}
 
 		this.i18n = i18next;
 

--- a/lib/utilities/sentry.ts
+++ b/lib/utilities/sentry.ts
@@ -43,8 +43,8 @@ export default function init(): typeof Sentry & {
 				Sentry.withScope((scope) => {
 					scope.setExtra("Environment", env.NODE_ENV);
 					scope.setUser({
-						username: (interaction.member?.user ?? interaction.user!).username,
-						id: (interaction.member?.user ?? interaction.user!).id,
+						username: (interaction.member ?? interaction).user!.username,
+						id: (interaction.member ?? interaction).user!.id,
 					});
 					scope.setExtra("Interaction", format(interaction));
 
@@ -65,7 +65,7 @@ export default function init(): typeof Sentry & {
 				Sentry.withScope((scope) => {
 					scope.setExtra("Environment", env.NODE_ENV);
 					scope.setUser({
-						username: `${message.author.username}#${message.author.discriminator}`,
+						username: message.author.username,
 						id: message.author.id,
 					});
 					scope.setExtra("Message", format(message));

--- a/src/bot/applicationCommands/events/redeemCode.ts
+++ b/src/bot/applicationCommands/events/redeemCode.ts
@@ -104,7 +104,7 @@ export default class RedeemCode extends ApplicationCommand {
 				eventId: event.id,
 				OR: [
 					{
-						userId: (interaction.member?.user ?? interaction.user!).id,
+						userId: (interaction.member ?? interaction).user!.id,
 					},
 					{
 						runpodEmail: email,
@@ -134,7 +134,7 @@ export default class RedeemCode extends ApplicationCommand {
 		}
 
 		const userCreationEpoch = Number(
-			(BigInt((interaction.member?.user ?? interaction.user!).id) >> 22n) + 1_420_070_400_000n,
+			(BigInt((interaction.member ?? interaction).user!.id) >> 22n) + 1_420_070_400_000n,
 		);
 
 		if (Date.now() - userCreationEpoch < 604_800_000)
@@ -150,7 +150,7 @@ export default class RedeemCode extends ApplicationCommand {
 				flags: MessageFlags.Ephemeral,
 			});
 
-		const userExistsResponse = await fetch(`https://api.runpod.io/graphql`, {
+		const userExistsResponse = await fetch("https://api.runpod.io/graphql", {
 			method: "POST",
 			body: JSON.stringify({
 				operationName: "getUserByEmail",
@@ -166,7 +166,7 @@ export default class RedeemCode extends ApplicationCommand {
 				"User-Agent":
 					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${env.RUNPOD_API_KEY}`,
+				Authorization: `Bearer ${env.RUNPOD_API_KEY}`,
 			},
 		});
 
@@ -194,7 +194,7 @@ export default class RedeemCode extends ApplicationCommand {
 				allowed_mentions: { parse: [], replied_user: true },
 			});
 
-		const generatedCodeResponse = await fetch(`https://api.runpod.io/graphql`, {
+		const generatedCodeResponse = await fetch("https://api.runpod.io/graphql", {
 			method: "POST",
 			body: JSON.stringify({
 				operationName: "generateCode",
@@ -209,7 +209,7 @@ export default class RedeemCode extends ApplicationCommand {
 				"User-Agent":
 					"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
 				"Content-Type": "application/json",
-				"Authorization": `Bearer ${env.RUNPOD_API_KEY}`,
+				Authorization: `Bearer ${env.RUNPOD_API_KEY}`,
 			},
 		});
 
@@ -229,7 +229,7 @@ export default class RedeemCode extends ApplicationCommand {
 					data: {
 						code: generatedCodeData.createCode.id,
 						runpodEmail: email,
-						userId: (interaction.member?.user ?? interaction.user!).id,
+						userId: (interaction.member ?? interaction).user!.id,
 						eventId: event.id,
 					},
 				}),
@@ -258,7 +258,7 @@ export default class RedeemCode extends ApplicationCommand {
 									email,
 									eventId: event.id,
 									eventName: event.name,
-									userMention: `<@${(interaction.member?.user ?? interaction.user!).id}>`,
+									userMention: `<@${(interaction.member ?? interaction).user!.id}>`,
 									creationDate: `<t:${Math.floor(userCreationEpoch / 1_000)}:R>`,
 									joinDate: `<t:${Math.floor(new Date(interaction.member!.joined_at).getTime() / 1_000)}:R>`,
 								}),

--- a/src/bot/applicationCommands/events/submit.ts
+++ b/src/bot/applicationCommands/events/submit.ts
@@ -96,7 +96,7 @@ export default class Submit extends ApplicationCommand {
 		const submission = await this.client.prisma.submission.findUnique({
 			where: {
 				userId_eventId: {
-					userId: (interaction.member?.user ?? interaction.user!).id,
+					userId: (interaction.member ?? interaction).user!.id,
 					eventId: event.id,
 				},
 			},
@@ -151,7 +151,7 @@ export default class Submit extends ApplicationCommand {
 								}?size=2048`,
 							},
 							image: {
-								url: `attachment://submission_${(interaction.member?.user ?? interaction.user!).id}.${extension}`,
+								url: `attachment://submission_${(interaction.member ?? interaction).user!.id}.${extension}`,
 							},
 							color: this.client.config.colors.primary,
 						},
@@ -164,7 +164,7 @@ export default class Submit extends ApplicationCommand {
 			attachments: [
 				{
 					id: attachment.id,
-					filename: `submission_${(interaction.member?.user ?? interaction.user!).id}.${extension}`,
+					filename: `submission_${(interaction.member ?? interaction).user!.id}.${extension}`,
 					description: "test",
 				},
 			],
@@ -187,7 +187,7 @@ export default class Submit extends ApplicationCommand {
 			files: [
 				{
 					data: buffer,
-					name: `submission_${(interaction.member?.user ?? interaction.user!).id}.${extension}`,
+					name: `submission_${(interaction.member ?? interaction).user!.id}.${extension}`,
 					key: `files[${attachment.id}]`,
 				},
 			],
@@ -198,7 +198,7 @@ export default class Submit extends ApplicationCommand {
 				data: {
 					eventId: event.id,
 					messageId: message.id,
-					userId: (interaction.member?.user ?? interaction.user!).id,
+					userId: (interaction.member ?? interaction).user!.id,
 				},
 			}),
 			this.client.api.interactions.reply(interaction.id, interaction.token, {

--- a/src/bot/applicationCommands/subscriptions/subscriptions.ts
+++ b/src/bot/applicationCommands/subscriptions/subscriptions.ts
@@ -350,7 +350,7 @@ export default class Ping extends ApplicationCommand {
 					this.client.languageHandler.defaultLanguage!.get(
 						"SUBSCRIPTIONS_COMMAND_SUBSCRIBE_SUB_COMMAND_USER_OPTION_NAME",
 					)
-				]?.id ?? (interaction.member?.user ?? interaction.user!).id;
+				]?.id ?? (interaction.member ?? interaction).user!.id;
 
 			return Promise.all([
 				this.client.prisma.subscribedUser.upsert({

--- a/src/bot/buttons/events/upvote.ts
+++ b/src/bot/buttons/events/upvote.ts
@@ -49,10 +49,10 @@ export default class Upvote extends Button {
 		return Promise.all([
 			this.client.prisma.submissionUpvote.upsert({
 				where: {
-					userId_eventId: { userId: (interaction.member?.user ?? interaction.user!).id, eventId: submission.eventId },
+					userId_eventId: { userId: (interaction.member ?? interaction).user!.id, eventId: submission.eventId },
 				},
 				create: {
-					userId: (interaction.member?.user ?? interaction.user!).id,
+					userId: (interaction.member ?? interaction).user!.id,
 					eventId: submission.eventId,
 					submissionId: submission.messageId,
 				},

--- a/src/bot/events/guildCreate.ts
+++ b/src/bot/events/guildCreate.ts
@@ -21,10 +21,10 @@ export default class GuildCreate extends EventHandler {
 		this.client.guildRolesCache.set(guild.id, guildRoles);
 		this.client.approximateUserCount += guild.member_count;
 
-		this.client.dataDog.gauge("guild_members", guild.member_count, [`guildId:${guild.id}`]);
+		this.client.dataDog?.gauge("guild_members", guild.member_count, [`guildId:${guild.id}`]);
 
 		if (this.client.guildOwnersCache.get(guild.id) === undefined) {
-			this.client.dataDog.increment("guild_count", 1, [`shard:${shardId}`]);
+			this.client.dataDog?.increment("guild_count", 1, [`shard:${shardId}`]);
 
 			this.client.guildOwnersCache.set(guild.id, guild.owner_id);
 

--- a/src/bot/events/guildDelete.ts
+++ b/src/bot/events/guildDelete.ts
@@ -16,7 +16,7 @@ export default class GuildDelete extends EventHandler {
 	public override async run({ shardId, data: guild }: ToEventProps<GatewayGuildDeleteDispatchData>) {
 		if (guild.unavailable) return;
 
-		this.client.dataDog.increment("guild_count", -1, [`shard:${shardId}`]);
+		this.client.dataDog?.increment("guild_count", -1, [`shard:${shardId}`]);
 
 		this.client.guildRolesCache.delete(guild.id);
 		this.client.guildOwnersCache.delete(guild.id);

--- a/src/bot/events/guildMemberAdd.ts
+++ b/src/bot/events/guildMemberAdd.ts
@@ -17,7 +17,7 @@ export default class GuildMemberAdd extends EventHandler {
 	public override async run({ data: member }: ToEventProps<GatewayGuildMemberAddDispatchData>) {
 		this.client.approximateUserCount++;
 
-		this.client.dataDog.increment("guild_members", 1, [`guildId:${member.guild_id}`]);
+		this.client.dataDog?.increment("guild_members", 1, [`guildId:${member.guild_id}`]);
 
 		const newInvites = await this.client.api.guilds.getInvites(member.guild_id);
 
@@ -28,11 +28,11 @@ export default class GuildMemberAdd extends EventHandler {
 		const usedInvite = newInvites.find((invite) => invite.uses > (invitesCache?.get(invite.code) ?? 0));
 
 		if (usedInvite) {
-			this.client.dataDog.increment("guild_joins", 1, [`guildId:${member.guild_id}`, `invite:${usedInvite.code}`]);
+			this.client.dataDog?.increment("guild_joins", 1, [`guildId:${member.guild_id}`, `invite:${usedInvite.code}`]);
 
 			invitesCache.set(usedInvite.code, usedInvite.uses);
 			this.client.invitesCache.set(member.guild_id, invitesCache);
-		} else this.client.dataDog.increment("guild_joins", 1, [`guildId:${member.guild_id}`]);
+		} else this.client.dataDog?.increment("guild_joins", 1, [`guildId:${member.guild_id}`]);
 
 		const [loggingChannels] = await Promise.all([
 			this.client.prisma.logChannel.findMany({

--- a/src/bot/events/guildMemberRemove.ts
+++ b/src/bot/events/guildMemberRemove.ts
@@ -17,8 +17,8 @@ export default class GuildMemberAdd extends EventHandler {
 	public override async run({ data: member }: ToEventProps<GatewayGuildMemberRemoveDispatchData>) {
 		this.client.approximateUserCount--;
 
-		this.client.dataDog.increment("guild_members", -1, [`guildId:${member.guild_id}`]);
-		this.client.dataDog.increment("guild_leaves", 1, [`guildId:${member.guild_id}`]);
+		this.client.dataDog?.increment("guild_members", -1, [`guildId:${member.guild_id}`]);
+		this.client.dataDog?.increment("guild_leaves", 1, [`guildId:${member.guild_id}`]);
 
 		const loggingChannels = await this.client.prisma.logChannel.findMany({
 			where: {

--- a/src/bot/events/interactionCreate.ts
+++ b/src/bot/events/interactionCreate.ts
@@ -18,13 +18,13 @@ export default class InteractionCreate extends EventHandler {
 		// This is very cursed, but it works.
 		const dd = data.data as any;
 
-		this.client.dataDog.increment("interactions_created", 1, [
+		this.client.dataDog?.increment("interactions_created", 1, [
 			`name:${dd.name ?? dd.custom_id ?? "null"}`,
 			`type:${data.type.toString()}`,
 			`shard:${shardId}`,
 		]);
 
-		this.client.dataDog.increment("user_locales", 1, [
+		this.client.dataDog?.increment("user_locales", 1, [
 			`locale:${(data.member?.user ?? data.user!).locale ?? this.client.languageHandler.defaultLanguage!.id}`,
 			`shard:${shardId}`,
 		]);

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -38,7 +38,7 @@ export default class MessageCreate extends EventHandler {
 			} else throw error;
 		}
 
-		this.client.dataDog.increment("total_messages_sent", 1, [
+		this.client.dataDog?.increment("total_messages_sent", 1, [
 			`guildId:${message.guild_id ?? "@me"}`,
 			`userId:${message.author.id}`,
 			`channelId:${message.channel_id}`,
@@ -53,14 +53,14 @@ export default class MessageCreate extends EventHandler {
 				(parentChannel.type === ChannelType.GuildForum &&
 					parentChannel.parent_id !== this.client.config.supportCategoryId)
 			)
-				this.client.dataDog.increment("total_messages_sent.engaging", 1, [
+				this.client.dataDog?.increment("total_messages_sent.engaging", 1, [
 					`guildId:${message.guild_id ?? "@me"}`,
 					`userId:${message.author.id}`,
 					`channelId:${message.channel_id}`,
 					`channelName:${channel?.name}`,
 				]);
 		} else if (channel?.type === ChannelType.GuildText && channel.parent_id !== this.client.config.supportCategoryId) {
-			this.client.dataDog.increment("total_messages_sent.engaging", 1, [
+			this.client.dataDog?.increment("total_messages_sent.engaging", 1, [
 				`guildId:${message.guild_id ?? "@me"}`,
 				`userId:${message.author.id}`,
 				`channelId:${message.channel_id}`,
@@ -74,7 +74,7 @@ export default class MessageCreate extends EventHandler {
 			// messages for certain new users, etc.) This will also enable us to track if new users might be having trouble getting around in the
 			// Discord server, and if we need an easier onboarding flow for it.
 			if (new Date(message.member!.joined_at).getTime() > Date.now() - 604_800_000)
-				this.client.dataDog.increment("total_messages_sent.new_user", 1, [
+				this.client.dataDog?.increment("total_messages_sent.new_user", 1, [
 					`guildId:${message.guild_id}`,
 					`userId:${message.author.id}`,
 					`channelId:${message.channel_id}`,
@@ -99,10 +99,10 @@ export default class MessageCreate extends EventHandler {
 					},
 				});
 
-				this.client.dataDog.increment("new_communicators", 1, [`guildId:${message.guild_id}`]);
+				this.client.dataDog?.increment("new_communicators", 1, [`guildId:${message.guild_id}`]);
 
 				if (new Date(message.member!.joined_at).getTime() + 86_400 > Date.now())
-					this.client.dataDog.increment("new_communicators_first_day", 1, [`guildId:${message.guild_id}`]);
+					this.client.dataDog?.increment("new_communicators_first_day", 1, [`guildId:${message.guild_id}`]);
 			}
 
 			const autoThreadChannel = await this.client.prisma.autoThreadChannel.findUnique({
@@ -112,12 +112,7 @@ export default class MessageCreate extends EventHandler {
 			if (autoThreadChannel) {
 				const name = autoThreadChannel.threadName
 					? autoThreadChannel.threadName
-							.replaceAll(
-								"{{author}}",
-								`${message.author.username}${
-									message.author.discriminator === "0" ? "" : `#${message.author.discriminator}`
-								}`,
-							)
+							.replaceAll("{{author}}", `${message.author.username}`)
 							.replaceAll("{{content}}", message.content)
 					: message.content;
 

--- a/src/bot/events/ready.ts
+++ b/src/bot/events/ready.ts
@@ -17,7 +17,7 @@ export default class Ready extends EventHandler {
 	 * https://discord.com/developers/docs/topics/gateway-events#ready
 	 */
 	public override async run({ shardId, data }: ToEventProps<GatewayReadyDispatchData>) {
-		this.client.dataDog.gauge("guild_count", data.guilds.length, [`shard:${shardId}`]);
+		this.client.dataDog?.gauge("guild_count", data.guilds.length, [`shard:${shardId}`]);
 
 		await Promise.all(
 			data.guilds.map(async (guild) => {
@@ -56,14 +56,14 @@ export default class Ready extends EventHandler {
 		});
 
 		schedule("* * * * *", async () => {
-			this.client.dataDog.gauge("guilds", this.client.guildOwnersCache.size);
-			this.client.dataDog.gauge("approximate_user_count", this.client.approximateUserCount);
+			this.client.dataDog?.gauge("guilds", this.client.guildOwnersCache.size);
+			this.client.dataDog?.gauge("approximate_user_count", this.client.approximateUserCount);
 
 			for (const [guildId, usersInVoice] of this.client.usersInVoice.entries())
-				this.client.dataDog.increment("minutes_in_voice", usersInVoice.size, [`guild:${guildId}`]);
+				this.client.dataDog?.increment("minutes_in_voice", usersInVoice.size, [`guild:${guildId}`]);
 
 			if (env.DATADOG_API_KEY)
-				this.client.dataDog.flush(
+				this.client.dataDog?.flush(
 					() => {
 						if (env.NODE_ENV === "development") this.client.logger.debug("Flushed DataDog metrics.");
 					},

--- a/src/bot/events/threadCreate.ts
+++ b/src/bot/events/threadCreate.ts
@@ -36,7 +36,7 @@ export default class ThreadCreate extends EventHandler {
 
 		const tagIds = [...new Set((channel.applied_tags ?? []).concat(autoTagOnForumChannel.map(({ tagId }) => tagId)))];
 
-		this.client.dataDog.increment("forum_posts", 1, [
+		this.client.dataDog?.increment("forum_posts", 1, [
 			`channelId:${parentChannel.id}`,
 			`guildId:${channel.guild_id}`,
 			`userId:${channel.owner_id}`,

--- a/src/bot/textCommands/admin/eval.ts
+++ b/src/bot/textCommands/admin/eval.ts
@@ -39,7 +39,7 @@ export default class Eval extends TextCommand {
 		shardId: number;
 	}) {
 		this.client.logger.info(
-			`${message.author.username}#${message.author.discriminator} ran eval in ${message.guild_id}, ${args.join(" ")}`,
+			`@${message.author.username} (${message.author.id}) ran eval in ${message.guild_id}, ${args.join(" ")}`,
 		);
 
 		const { success, result, time, type } = await this.eval(message, args.join(" "));

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,7 @@ import ExtendedClient from "../lib/extensions/ExtendedClient.js";
 import type PoddyFunctions from "./utilities/functions";
 
 export class PoddyClient extends ExtendedClient {
-	override get functions(): PoddyFunctions {
+	override get functions() {
 		return super.functions as PoddyFunctions;
 	}
 }


### PR DESCRIPTION
prep work for stripping the lib out of Poddy + simplifying some logic around how we grab the id of the interacting member.

I also removed where we use discriminators, its the future. 

this pr targets `dj/dedupe-zendesk-code`, github will only show the commits this pr introduces vs targeting main where it'll show both. when #6 is merged, gh should auto change the merge target to main and keep the commits/changes clean :)