### PR TITLE
allow team members to view escalated zendesk embeds

### DIFF
--- a/config/bot.config.ts
+++ b/config/bot.config.ts
@@ -19,7 +19,7 @@ export default {
 	/**
 	 * A list of users that are marked as administrators of the bot, these users have access to eval commands.
 	 */
-	admins: ["619284841187246090"],
+	admins: ["619284841187246090", "194861788926443520"],
 
 	/**
 	 * The presence that should be displayed when the bot starts running.

--- a/src/bot/buttons/zendesk/escalateToZendesk.ts
+++ b/src/bot/buttons/zendesk/escalateToZendesk.ts
@@ -2,11 +2,14 @@ import {
 	type APIMessageComponentButtonInteraction,
 	ComponentType,
 	MessageFlags,
+	PermissionFlagsBits,
 	TextInputStyle,
 } from "@discordjs/core";
+import { BitField } from "@sapphire/bitfield";
 import Button from "../../../../lib/classes/Button.js";
 import type Language from "../../../../lib/classes/Language.js";
 import type ExtendedClient from "../../../../lib/extensions/ExtendedClient.js";
+import PermissionsBitField from "../../../../lib/utilities/permissions.js";
 
 export default class EscalateToZendesk extends Button {
 	/**
@@ -44,7 +47,10 @@ export default class EscalateToZendesk extends Button {
 			string,
 		];
 
-		if (escalatedUserId !== interaction.member!.user.id)
+		if (
+			escalatedUserId !== interaction.member!.user.id ||
+			!PermissionsBitField.has(BigInt(interaction.member!.permissions), PermissionFlagsBits.ViewAuditLog)
+		) {
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {
 				embeds: [
 					{
@@ -56,6 +62,7 @@ export default class EscalateToZendesk extends Button {
 				flags: MessageFlags.Ephemeral,
 				allowed_mentions: { parse: [], replied_user: true },
 			});
+		}
 
 		const ticket = await this.client.prisma.zendeskTicket.findUnique({
 			where: {

--- a/src/bot/buttons/zendesk/escalateToZendesk.ts
+++ b/src/bot/buttons/zendesk/escalateToZendesk.ts
@@ -48,7 +48,7 @@ export default class EscalateToZendesk extends Button {
 
 		if (
 			escalatedUserId !== interaction.member!.user.id ||
-			!PermissionsBitField.has(BigInt(interaction.member!.permissions), BigInt(PermissionFlagsBits.ViewAuditLog))
+			!PermissionsBitField.has(BigInt(interaction.member!.permissions), PermissionFlagsBits.ViewAuditLog)
 		) {
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {
 				embeds: [

--- a/src/bot/buttons/zendesk/escalateToZendesk.ts
+++ b/src/bot/buttons/zendesk/escalateToZendesk.ts
@@ -47,7 +47,7 @@ export default class EscalateToZendesk extends Button {
 		];
 
 		if (
-			escalatedUserId !== interaction.member!.user.id ||
+			escalatedUserId !== interaction.member!.user.id &&
 			!PermissionsBitField.has(BigInt(interaction.member!.permissions), PermissionFlagsBits.ViewAuditLog)
 		) {
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {

--- a/src/bot/buttons/zendesk/escalateToZendesk.ts
+++ b/src/bot/buttons/zendesk/escalateToZendesk.ts
@@ -5,7 +5,6 @@ import {
 	PermissionFlagsBits,
 	TextInputStyle,
 } from "@discordjs/core";
-import { BitField } from "@sapphire/bitfield";
 import Button from "../../../../lib/classes/Button.js";
 import type Language from "../../../../lib/classes/Language.js";
 import type ExtendedClient from "../../../../lib/extensions/ExtendedClient.js";

--- a/src/bot/buttons/zendesk/escalateToZendesk.ts
+++ b/src/bot/buttons/zendesk/escalateToZendesk.ts
@@ -48,7 +48,7 @@ export default class EscalateToZendesk extends Button {
 
 		if (
 			escalatedUserId !== interaction.member!.user.id ||
-			!PermissionsBitField.has(BigInt(interaction.member!.permissions), PermissionFlagsBits.ViewAuditLog)
+			!PermissionsBitField.has(BigInt(interaction.member!.permissions), BigInt(PermissionFlagsBits.ViewAuditLog))
 		) {
 			return this.client.api.interactions.reply(interaction.id, interaction.token, {
 				embeds: [


### PR DESCRIPTION
I've entirely arbitrarily limited this to View Audit Log, a permission the Team role already has. 