### PR TITLE
fix: update Zendesk ticket name assignment

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,8 @@
 import ExtendedClient from "../lib/extensions/ExtendedClient.js";
-import type PoddyFunctions from "./utilities/functions";
+import PoddyFunctions from "./utilities/functions.js";
 
 export class PoddyClient extends ExtendedClient {
-	override get functions() {
-		return super.functions as PoddyFunctions;
+	override get functions(): PoddyFunctions {
+		return new PoddyFunctions(this);
 	}
 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -8,7 +8,7 @@ import {
 } from "discord-api-types/v10";
 import botConfig from "../../config/bot.config.js";
 import type ExtendedClient from "../../lib/extensions/ExtendedClient.js";
-import Functions from "../../lib/utilities/functions";
+import Functions from "../../lib/utilities/functions.js";
 import type { ZendeskCreateTicketRequest, ZendeskCreateTicketResponse } from "../../typings/zendesk.js";
 
 type SubmittableTicket = {
@@ -39,8 +39,8 @@ export default class PoddyFunctions extends Functions {
 				ticket: {
 					subject: ticket.subject ?? `${type[0]?.toUpperCase() + type.slice(1)} Escalated From Discord`, // "message" => "Message", shorter than a ternary
 					comment: ticket.comment,
-					requester: { email, name: user.username },
-					tags: [...(ticket.tags ?? []), "discord"],
+					requester: { email, name: interaction.member.user.username },
+					tags: ["discord"],
 				} satisfies ZendeskCreateTicketRequest,
 			}),
 			method: "POST",


### PR DESCRIPTION
use the name of the person who submitted the ticket instead of the person who escalated the ticket.